### PR TITLE
fix: properly access configuration keymaps

### DIFF
--- a/lua/highlight-undo.lua
+++ b/lua/highlight-undo.lua
@@ -100,7 +100,7 @@ function M.setup(config)
   })
 
   M.config = vim.tbl_deep_extend('keep', config or {}, M.config)
-  for _, mapping in ipairs(config.keymaps) do
+  for _, mapping in ipairs(M.config.keymaps) do
     vim.keymap.set(mapping[1], mapping[2], function()
         M.highlight_undo(0, function()
           M.call_original_kemap(mapping[3])


### PR DESCRIPTION
Problem:
When the user does not set keymaps in their
configuration, "config.keymaps" is nil, resulting
in an error in the call to ipairs.

Why:
ipairs receives "config.keymaps", but "M.config"
is the variable used to hold the tbl which is the
combination of the default config and the user
config.

Solution:
Pass M.config.keymaps to ipairs, not
config.keymaps.