### PR TITLE
feature!: add different highlight groups for undo and redo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,45 +3,52 @@
 Highlight changed text after Undo / Redo operations. Purely lua / nvim api implementation,
 no external dependencies needed.
 
-# In Action
+## In Action
 
 ![recording](https://github.com/tzachar/highlight-undo.nvim/assets/4946827/81b85a3b-b563-4e97-b4e1-7a48d0d2f912)
 
-# install
+## Installation
 
 Using Lazy:
 
 ```lua
   {
-      'tzachar/highlight-undo.nvim',
-      config = function()
-        require('highlight-undo').setup({
-            ...
-          })
-      end
+    'tzachar/highlight-undo.nvim',
+    opts = {
+      ...
+    },
   },
 ```
 
-# Setup
+## Setup
 
-You can setup `highlight-undo` as follows:
+You can manually setup `highlight-undo` as follows:
 
 ```lua
 require('highlight-undo').setup({
+  duration = 300,
+  undo = {
     hlgroup = 'HighlightUndo',
-    duration = 300,
-    keymaps = {
-      {'n', 'u', 'undo', {}},
-      {'n', '<C-r>', 'redo', {}},
-    }
+    mode = 'n',
+    lhs = 'u',
+    map = 'undo',
+    opts = {}
+  },
+  redo = {
+    hlgroup = 'HighlightUndo',
+    mode = 'n',
+    lhs = '<C-r>',
+    map = 'redo',
+    opts = {}
+  },
 })
 ```
 
-## keymaps
+## Keymaps
 
-Specify which kemaps should trigger the beginning and end of tracking changes
-([see here](#how-the-plugin-works)). By
-default, the plugin starts tracking changes before an `undo` or a `redo`.
+Specify which keymaps should trigger the beginning and end of tracking changes
+([see here](#how-the-plugin-works)). By default, the plugin starts tracking
+changes before an `undo` or a `redo`.
 
 Keymaps are specified in the same format as `vim.keymap.set` accepts: mode, lhs,
 rhs, opts. Maps are passed verbatim to `vim.keymap.set`.
@@ -57,10 +64,10 @@ use any other group you desire.
 
 ## `duration`
 
-The duration (in milliseconds) highligh changes. Default is 300.
+The duration (in milliseconds) to highlight changes. Default is 300.
 
-# How the Plugin Works
+## How the Plugin Works
 
-`highlight-undo` will remap the `u` and `<C-r>` keys (for undo and redo, be default) and
-hijack the calls. By utilizing nvim_buf_attach to get indications for changes in the
+`highlight-undo` will remap the `u` and `<C-r>` keys (for undo and redo, by default) and
+hijack the calls. By utilizing `nvim_buf_attach` to get indications for changes in the
 buffer, the plugin can achieve very low overhead.

--- a/lua/highlight-undo.lua
+++ b/lua/highlight-undo.lua
@@ -5,13 +5,20 @@ local api = vim.api
 
 local M = {
   config = {
-    hlgroup = 'HighlightUndo',
-    undo_hlgroup = nil,
-    redo_hlgroup = nil,
     duration = 300,
-    keymaps = {
-      { 'n', 'u', 'undo', {} },
-      { 'n', '<C-r>', 'redo', {} },
+    undo = {
+      hlgroup = 'HighlightUndo',
+      mode = 'n',
+      lhs = 'u',
+      map = 'undo',
+      opts = {},
+    },
+    redo = {
+      hlgroup = 'HighlightUndo',
+      mode = 'n',
+      lhs = '<C-r>',
+      map = 'redo',
+      opts = {},
     },
   },
   timer = (vim.uv or vim.loop).new_timer(),
@@ -104,19 +111,19 @@ function M.setup(config)
 
   M.config = vim.tbl_deep_extend('keep', config or {}, M.config)
 
-  local undo_mapping = M.config.keymaps[1]
-  vim.keymap.set(undo_mapping[1], undo_mapping[2], function()
-    M.highlight_undo(0, M.config.undo_hlgroup or M.config.hlgroup, function()
-      M.call_original_kemap(undo_mapping[3])
+  local undo = M.config.undo
+  vim.keymap.set(undo.mode, undo.lhs, function()
+    M.highlight_undo(0, undo.hlgroup, function()
+      M.call_original_kemap(undo.map)
     end)
-  end, undo_mapping[4])
+  end, undo.opts)
 
-  local redo_mapping = M.config.keymaps[2]
-  vim.keymap.set(redo_mapping[1], redo_mapping[2], function()
-    M.highlight_undo(0, M.config.redo_hlgroup or M.config.hlgroup, function()
-      M.call_original_kemap(redo_mapping[3])
+  local redo = M.config.redo
+  vim.keymap.set(redo.mode, redo.lhs, function()
+    M.highlight_undo(0, redo.hlgroup, function()
+      M.call_original_kemap(redo.map)
     end)
-  end, redo_mapping[4])
+  end, redo.opts)
 end
 
 return M

--- a/lua/highlight-undo.lua
+++ b/lua/highlight-undo.lua
@@ -6,14 +6,17 @@ local api = vim.api
 local M = {
   config = {
     hlgroup = 'HighlightUndo',
+    undo_hlgroup = nil,
+    redo_hlgroup = nil,
     duration = 300,
     keymaps = {
-      {'n', 'u', 'undo', {}},
-      {'n', '<C-r>', 'redo', {}},
-    }
+      { 'n', 'u', 'undo', {} },
+      { 'n', '<C-r>', 'redo', {} },
+    },
   },
   timer = (vim.uv or vim.loop).new_timer(),
   should_detach = true,
+  current_hlgroup = nil,
 }
 
 local usage_namespace = api.nvim_create_namespace('highlight_undo')
@@ -22,10 +25,9 @@ function M.call_original_kemap(map)
   if type(map) == 'string' then
     vim.cmd(map)
   elseif type(map) == 'function' then
-      map()
+    map()
   end
 end
-
 
 function M.on_bytes(
   ignored, ---@diagnostic disable-line
@@ -62,7 +64,7 @@ function M.on_bytes(
   -- )
   -- defer highligh till after changes take place..
   vim.schedule(function()
-    vim.highlight.range(bufnr, usage_namespace, M.config.hlgroup, { start_row, start_column }, {
+    vim.highlight.range(bufnr, usage_namespace, M.current_hlgroup, { start_row, start_column }, {
       start_row + new_end_row,
       start_column + new_end_col,
     })
@@ -72,7 +74,8 @@ function M.on_bytes(
   -- return true
 end
 
-function M.highlight_undo(bufnr, command)
+function M.highlight_undo(bufnr, hlgroup, command)
+  M.current_hlgroup = hlgroup
   api.nvim_buf_attach(bufnr, false, {
     on_bytes = M.on_bytes,
   })
@@ -100,14 +103,20 @@ function M.setup(config)
   })
 
   M.config = vim.tbl_deep_extend('keep', config or {}, M.config)
-  for _, mapping in ipairs(M.config.keymaps) do
-    vim.keymap.set(mapping[1], mapping[2], function()
-        M.highlight_undo(0, function()
-          M.call_original_kemap(mapping[3])
-        end)
-      end,
-      mapping[4])
-  end
+
+  local undo_mapping = M.config.keymaps[1]
+  vim.keymap.set(undo_mapping[1], undo_mapping[2], function()
+    M.highlight_undo(0, M.config.undo_hlgroup or M.config.hlgroup, function()
+      M.call_original_kemap(undo_mapping[3])
+    end)
+  end, undo_mapping[4])
+
+  local redo_mapping = M.config.keymaps[2]
+  vim.keymap.set(redo_mapping[1], redo_mapping[2], function()
+    M.highlight_undo(0, M.config.redo_hlgroup or M.config.hlgroup, function()
+      M.call_original_kemap(redo_mapping[3])
+    end)
+  end, redo_mapping[4])
 end
 
 return M


### PR DESCRIPTION
Resolves #12 and maintains backwards compatibility through config object. Some thoughts for future improvements:

The `config` object may be cleaner if fields for undo and redo actions (and their sub-fields) are referred to through explicit fields rather than an array. Something like:

```lua
config = {
    hlgroup = 'HighlightUndo',
    undo_hlgroup = nil,
    redo_hlgroup = nil,
    duration = 300,
	undo = { 
		mode = 'n', 
		lhs = 'u', 
		map = 'undo',
	},
	redo = { 
		mode = 'n', 
		lhs = '<C-r>', 
		map = 'redo',
	},
},
```

This does however break backwords compatibility. Please let me know your thoughts. Thanks!