### PR TITLE
fix: pasting

### DIFF
--- a/lua/highlight-undo.lua
+++ b/lua/highlight-undo.lua
@@ -145,8 +145,8 @@ local function hijack(opts, org_mapping)
           vim.api.nvim_feedkeys(keys, org_mapping.mode, false)
         end
       elseif opts.rhs and type(opts.rhs) == "string" then
-        local keys = vim.api.nvim_replace_termcodes(org_mapping.rhs, true, false, true)
-        vim.api.nvim_feedkeys(opts.rhs, opts.mode, false)
+        local keys = vim.api.nvim_replace_termcodes(opts.rhs, true, false, true)
+        vim.api.nvim_feedkeys(keys, opts.mode, false)
       elseif opts.command and type(opts.command) == "string" then
         vim.cmd(opts.command)
       elseif opts.opts.callback then


### PR DESCRIPTION
## Problem

Pasting used to trigger a Lua error, because it was attempting to call `vim.api,nvim_replace_termcodes` with `nil` as the first parameter (`org_mapping.rhs`), and the function expected a valid `string`.

```
E5108: Error executing lua: ...are/nvim/lazy/highlight-undo.nvim/lua/highlight-undo.lua:148: Invalid 'str': Expected Lua string
stack traceback:
        [C]: in function 'nvim_replace_termcodes'
        ...are/nvim/lazy/highlight-undo.nvim/lua/highlight-undo.lua:148: in function 'command'
        ...are/nvim/lazy/highlight-undo.nvim/lua/highlight-undo.lua:112: in function 'highlight_undo'
        ...are/nvim/lazy/highlight-undo.nvim/lua/highlight-undo.lua:131: in function <...are/nvim/lazy/highlight-undo.nvim/lua/highlight-undo
.lua:130>
```

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/76a30327-f206-47a2-8d52-4fc717ee7ec5">

This happened because the code was referring to `org_mapping`, which was known to be an empty table in this conditional branch.

Moreover, the `keys` variable was not used, and the call to `vim.api.nvim_feedkeys` referred to the original, unreplaced `opts.rhs`.




## Solution

Use the correct `opts.rhs` argument when calling `vim.api.nvim_replace_termcodes`, and then use the `keys` variable when calling `vim.api.nvim_feedkeys`.

The plugin works as expected now


https://github.com/user-attachments/assets/fad78857-3180-4929-94d2-9c3ddd4f0c13



This fixes a bug that prevented the `p` and `P` keymaps from working when this plugin was hijacking those mappings. Caused by9cf8f052e86a5a323b16d17bad12f7cb73b248eb