### PR TITLE
Comment-out Keymap_name example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ You can manually setup `highlight-undo` as follows:
 require('highlight-undo').setup({
   duration = 300,
   keymaps = {
-    Keymap_name = {
-      -- most fields here are the same as in vim.keymap.set
-      desc = "a description",
-      hlgroup = 'HighlightUndo',
-      mode = 'n',
-      lhs = 'lhs',
-      rhs = 'optional, can be nil',
-      opts = {
-        -- same as opts to vim.keymap.set. if rhs is nil, there should be a
-        -- callback key which points to a function
-      },
-    },
+    --Keymap_name = {
+    --  -- most fields here are the same as in vim.keymap.set
+    --  desc = "a description",
+    --  hlgroup = 'HighlightUndo',
+    --  mode = 'n',
+    --  lhs = 'lhs',
+    --  rhs = 'optional, can be nil',
+    --  opts = {
+    --    -- same as opts to vim.keymap.set. if rhs is nil, there should be a
+    --    -- callback key which points to a function
+    --  },
+    --},
   },
 })
 ```


### PR DESCRIPTION
Using it in highlight-undo.lua causes 'l' to be mapped.