### PR TITLE
feat: provide a default ignore fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Which file types to ignore, regardless of `patter`.
 
 ```lua
 require('highlight-undo').setup({
-        ignored_cb = function(buf) return false end,
+        ignore_cb = function(buf) return false end,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Using Lazy:
         hlgroup = "HighlightUndo",
         duration = 300,
         pattern = {"*"},
-        ignored_filetypes = { "neo-tree", "fugitive", " TelescopePrompt" },
+        ignored_filetypes = { "neo-tree", "fugitive", "TelescopePrompt" },
         ignore_cb = nil,
     },
   },
@@ -68,7 +68,7 @@ Which file patterns to atttach to. Default is everything (`*`).
 
 ```lua
 require('highlight-undo').setup({
-        ignored_filetypes = { "neo-tree", "fugitive", " TelescopePrompt" },
+        ignored_filetypes = { "neo-tree", "fugitive", "TelescopePrompt" },
 })
 ```
 

--- a/lua/highlight-undo.lua
+++ b/lua/highlight-undo.lua
@@ -10,12 +10,28 @@ function Tracker:new(config, buf)
   self.config = config
 end
 
+local default_ignore_cb = function(buf)
+  local bo = vim.bo[buf]
+
+  -- Check for special buffer types, e.g. lazy, telescope
+  if bo.buftype ~= "" then
+    return true
+  end
+
+  -- Check if buffer is modifiable
+  if not bo.modifiable then
+    return true
+  end
+
+  return false
+end
+
 local config = {
   duration = 300,
   hlgroup = "HighlightUndo",
   pattern = { "*" },
-  ignored_filetypes = { "neo-tree", "fugitive", " TelescopePrompt" },
-  ignore_cb = nil,
+  ignored_filetypes = { "neo-tree", "fugitive", "TelescopePrompt" },
+  ignore_cb = default_ignore_cb,
 }
 
 local buffers = {}


### PR DESCRIPTION
I think it would be a good idea to ignore all special buffers and nonte editable buffers by default. Still keep the `nil` check for `ignore_cb` in case the user want to not ignore anything.

* also fixed two typos